### PR TITLE
Implemented Graph Deletion Before Graph Build or User Logout

### DIFF
--- a/sonar/authmngr/views.py
+++ b/sonar/authmngr/views.py
@@ -5,6 +5,7 @@ from rest_framework.authtoken.models import Token
 from rest_framework.permissions import IsAuthenticated
 from django.contrib.auth import authenticate, login, logout
 from .serializers import *
+from graph.neo4j_graph_client import Neo4jGraphClient
 
 class RegisterView(APIView):
 
@@ -55,6 +56,8 @@ class LogoutView(APIView):
     def get(self, request):
 
         request.user.auth_token.delete()
+        neo4j_graph_client = Neo4jGraphClient()
+        neo4j_graph_client.delete_user_graph(username=request.user.username)
         logout(request)
         return Response(status=status.HTTP_200_OK)
         

--- a/sonar/graph/neo4j_graph_client.py
+++ b/sonar/graph/neo4j_graph_client.py
@@ -126,3 +126,15 @@ class Neo4jGraphClient(Neo4jClient):
                 set c.owner = $username
             """, username=username)
     
+    def delete_user_graph(self, username):
+
+        with self.driver.session() as session:
+            session.execute_write(Neo4jGraphClient._delete_user_graph, username=username)
+
+    def _delete_user_graph(tx, username):
+            
+            tx.run("""
+                MATCH (n)
+                WHERE n.owner = $username
+                DETACH DELETE n
+            """, username=username)

--- a/sonar/graph/views.py
+++ b/sonar/graph/views.py
@@ -149,6 +149,8 @@ class BuildGraphView(APIView):
         author_nodes = set()
         authorship_edges = set()
 
+        print("Retrieving Data ...")
+
         with cf.ThreadPoolExecutor(max_workers=100) as executor:
             
             futures = [executor.submit(self.paper_retriever.retrieve_paper, article_doi) for article_doi in article_doi_set]
@@ -176,6 +178,8 @@ class BuildGraphView(APIView):
         print("Data retrieved in " + str(data_retrieval_time) + " seconds")
 
         print("Building graph ...")
+
+        self.neo4j_graph_client.delete_user_graph(username=user.username)
 
         self.neo4j_graph_client.create_article_nodes_batch(article_set=article_nodes, username=user.username)
         self.neo4j_graph_client.create_citation_edges_batch(citation_set=citation_edges, batch_size=500, username=user.username)


### PR DESCRIPTION
The graph of a user in the neo4j DB is now deleted before the user builds another graph or logs out.